### PR TITLE
Add evil-escape to sample config

### DIFF
--- a/sample-config/init.el
+++ b/sample-config/init.el
@@ -96,6 +96,14 @@
 ;; configure signals, see `user-signal.el' (visit it with `SPC f e s')
 (use-package js-comint)
 
+;; Customizable key sequence to escape from insert state. Defaults to `fd'
+(use-package evil-escape
+  :straight (evil-escape :type git :host github :repo "syl20bnr/evil-escape"
+                         :fork (:host github :repo "emacsorphanage/evil-escape"))
+  :diminish evil-escape-mode
+  :config
+  (evil-escape-mode))
+
 ;; Start the emacs-server, so you can open files from the command line with
 ;; `emacsclient -n <file>' (we like to put `alias en="emacsclient -n"' in our
 ;; shell config).


### PR DESCRIPTION
Closes #24

Decided to go with a recently maintained [fork from emacsorphanage](https://github.com/emacsorphanage/evil-escape) maintained by well known Emacs community members 